### PR TITLE
Additional isset check for array index on $before

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -332,7 +332,7 @@ class Compiler
 
                     // remove shared parts
                     if ($initial) {
-                        while ($k < $s && isset($new[$k]) && $before[$k] === $new[$k]) {
+                        while ($k < $s && isset($new[$k]) && isset($before[$k]) && $before[$k] === $new[$k]) {
                             $k++;
                         }
                     }


### PR DESCRIPTION
Various projects are throwing the following warning: 

`PHP Notice:  Undefined offset: 0 in leafo/scssphp/src/Compiler.php on line 279`
